### PR TITLE
minor refactoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,58 @@
+# ansible
+secrets.yml
+inventory.ini
+
+# editor
+.DS_Store
+**/.DS_Store
+.vscode
+.idea
+**/.idea
+*.iml
+*.ipr
+
+# Icon must end with two \r
+Icon
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+### Linux ###
+*~
+
+# temporary files which can be created if a process still has a handle open of a deleted file
+.fuse_hidden*
+
+# KDE directory preferences
+.directory
+
+# Linux trash folder which might appear on any partition or disk
+.Trash-*
+
+# .nfs files are created when an open file is removed but is still being accessed
+.nfs*
+
+# token
+.token.env
+*.token.env
+*.token.env.*
+*.env
+*.token
+env
+.env

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ansible-node-exporter
 
 `node_exporter_version` 
-- **Description:** Version of node-exporter to be install
+- **Description:** Version of node-exporter to be installed
 - **Default:** `1.3.1`
 
 `node_exporter_listen_localhost`

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,3 +1,4 @@
 ---
 node_exporter_version: 1.3.1
 node_exporter_listen_localhost: false
+node_exporeter_binary: https://github.com/prometheus/node_exporter/releases/download/v{{ node_exporter_version }}/node_exporter-{{ node_exporter_version }}.linux-amd64.tar.gz

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,4 @@
 ---
 node_exporter_version: 1.3.1
 node_exporter_listen_localhost: false
-node_exporeter_binary: https://github.com/prometheus/node_exporter/releases/download/v{{ node_exporter_version }}/node_exporter-{{ node_exporter_version }}.linux-amd64.tar.gz
+node_exporter_binary: https://github.com/prometheus/node_exporter/releases/download/v{{ node_exporter_version }}/node_exporter-{{ node_exporter_version }}.linux-amd64.tar.gz

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -26,7 +26,7 @@
 
 - name: Download Node Exporter
   unarchive:
-    src: "{{ node_exporeter_binary }}"
+    src: "{{ node_exporter_binary }}"
     dest: /opt/
     remote_src: yes
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -26,7 +26,7 @@
 
 - name: Download Node Exporter
   unarchive:
-    src: https://github.com/prometheus/node_exporter/releases/download/v{{ node_exporter_version }}/node_exporter-{{ node_exporter_version }}.linux-amd64.tar.gz
+    src: "{{ node_exporeter_binary }}"
     dest: /opt/
     remote_src: yes
 

--- a/tasks/templates/node_exporter.service.j2
+++ b/tasks/templates/node_exporter.service.j2
@@ -1,8 +1,15 @@
 [Unit]
 Description=Node Exporter
+After=network.target
 
 [Service]
+Type=simple
 User=node_exporter
+Group=node_exporter
+Restart=on-failure
+RestartSec=10
+StartLimitInterval=60
+Environment=GOMAXPROCS=1
 ExecStart=/opt/node_exporter/node_exporter --web.listen-address={{ node_exporter_listen_ip }}:9100 --collector.systemd --collector.textfile.directory="/opt/node_exporter/textfiles"
 
 [Install]


### PR DESCRIPTION
Refactoring:

☑️ Code refactoring
☑️ Typo correction

Description of Changes:

- added [.gitignore](https://github.com/hyphacoop/ansible-node-exporter/compare/main...afa-farkhod:development?expand=1#diff-bc37d034bad564583790a46f19d807abfe519c5671395fd494d8cce506c42947)  
   - avoids committing sensitive files like secrets, inventory files, and token files
   - excludes system-generated files from macOS, Linux, and remote file shares.
   - ignores editor and IDE configurations to maintain a clean repository.
   - excludes temporary and backup files from common text editors and operating systems.
- updated [README.md](https://github.com/hyphacoop/ansible-node-exporter/compare/main...afa-farkhod:development?expand=1#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5) fixed typo 
- updated [defaults/main.yml](https://github.com/hyphacoop/ansible-node-exporter/compare/main...afa-farkhod:development?expand=1#diff-23e21b6c89468f7534697ad091835b3ee5e0213b37ace489488234e5a9548ec4): added new `node_exporter_binary` variable of the binary source url link
- updated [tasks/main.yml](https://github.com/hyphacoop/ansible-node-exporter/compare/main...afa-farkhod:development?expand=1#diff-3d0ff1709ca48add100327bb2a468e6c508fb92a159c64c4f99ad1df89d9bdde) by replacing the binary url link with the variable which is given in the defaults
- updated [tasks/templates/node_exporter.service.j2](https://github.com/hyphacoop/ansible-node-exporter/compare/main...afa-farkhod:development?expand=1#diff-503e42ef50134a8d7ec02891690b40daafac64eb22757c0501d588d09e1ddf9d) service file template to include followings:
   - `After=network.target` ensures that node exporter starts after the network is up which avoids failures due to missing interface
   - `Type=simple` node exporter runs as a simple process without requiring separate daemon mode
   - `Group` also runs the service under the group
   - `Restart=on-failure` prevents unexpected crash, if service file fails due to an error, systemd restarts it automatically
   - `RestartSec=10` avoids excessive restart loops
   - `StartLimitInterval=60` if service file fails too many times within 60 sec, systemd stops trying to restart it
   - `Environment=GOMAXPROCS=1` avoids excessive CPU usage on multi core systems